### PR TITLE
Added link to ProvisionQL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -116,6 +116,15 @@ Run `brew cask install ipaql` or [download manually](http://kfi-apps.com/site/as
 
 ![](screenshots/ipaql.png)
 
+### [ProvisionQL](https://github.com/ealeksandrov/ProvisionQL)
+
+> Preview iOS / OS X app and provision information, iOS 7 & OSX 10.9 compatible
+
+Run `brew cask install provisionql` or [download manually](https://github.com/ealeksandrov/ProvisionQL/releases/download/1.0.0/ProvisionQL.zip)
+
+![Thumbnails example](https://raw.github.com/ealeksandrov/ProvisionQL/master/Screenshots/1.png)
+
+### Other great tools:
 
 - [Provisioning](https://github.com/chockenberry/Provisioning) - preview .mobileprovision (iOS) and .provisionprofile (OS X) files
 - [CertQuickLook](https://code.google.com/p/cert-quicklook/) - preview various unprotected certificate tokens like X509 certificates, DER or PEM


### PR DESCRIPTION
Check out [ProvisionQL](https://github.com/ealeksandrov/ProvisionQL) - open-source, based on [Provisioning](https://github.com/chockenberry/Provisioning).
Also available through [homebrew cask](https://github.com/caskroom/homebrew-cask/blob/master/Casks/provisionql.rb) :)

Inspired by number of existing alternatives, the goal of this project is to provide clean, reliable, current and open-source Quick Look plugin for iOS & OSX developers.

Thumbnails will show app icon for `.ipa` or expiring status and device count for `.mobileprovision`. Quick look preview will give a lot of information, including UUIDs, devices, certificates and much more.

Supporting file types:
- `.ipa` - iOS packaged application (both Xcode generated and from iTunes)
- `.app` - iOS application bundle
- `.mobileprovision` - iOS provisioning profile
- `.provisionprofile` - OSX provisioning profile

[More screenshots](https://github.com/ealeksandrov/ProvisionQL/blob/master/screenshots.md)
