### PR TITLE
readme: suggest ~/Library/QuickLook instead

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ brew cask install qlcolorcode qlstephen qlmarkdown quicklook-json qlprettypatch 
 ### Manually
 
 - Click "download manually"
-- Move the downloaded .qlgenerator file to /Library/QuickLook
+- Move the downloaded .qlgenerator file to `~/Library/QuickLook`
 - Run `qlmanage -r`
 
 


### PR DESCRIPTION
`~/Library/QuickLook` is the recommended directory for user installs. It does not require special permissions and any user can install on their own account without interfering with others (I’ve had quicklook plugins interfere with normal quicklook usage).

It’s also where we install to with Homebrew-Cask, so manual and `brew cask` automations will be in line.