### PR TITLE
Fix URLs for BetterZipQL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ Run `brew cask install quicklook-json` or [download manually](http://www.sagtau.
 [![](screenshots/QuickLookJSON.png)](http://www.sagtau.com/quicklookjson.html)
 
 
-### [BetterZipQL](http://macitbetter.com/BetterZip-Quick-Look-Generator/)
+### [BetterZipQL](https://macitbetter.com/downloads/)
 
 > Preview archives
 
@@ -69,7 +69,7 @@ Run `brew cask install quicklook-json` or [download manually](http://www.sagtau.
 
 Run `brew cask install betterzip` to install the BetterZip app and its Quick Look plugin or [download manually](https://macitbetter.com/BetterZip.zip)
 
-The legacy BetterZipQL plugin can be [downloaded here](http://macitbetter.com/BetterZipQL.zip).
+The legacy BetterZipQL plugin can be [downloaded here](https://macitbetter.com/dl/BetterZipQL-1.5.zip).
 
 [![](screenshots/BetterZipQL.png)](http://macitbetter.com/BetterZip-Quick-Look-Generator/)
 


### PR DESCRIPTION
This change fix the problem whenever one downloads
`BetterZipQL` plugin, it lacks some components so
the preview does not contain file icons. Only legacy version
`1,5` produces correct preview.