### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,9 +78,9 @@ The legacy BetterZipQL plugin can be [downloaded here](http://macitbetter.com/Be
 
 > Display image size and resolution
 
-Run `brew cask install qlimagesize` or [download manually](https://github.com/Nyx0uf/qlImageSize#installation)
+Run `brew cask install qlimagesize` or [download manually](https://github.com/L1cardo/qlImageSize#installation)
 
-[![](screenshots/qlImageSize.png)](https://github.com/Nyx0uf/qlImageSize)
+[![](screenshots/qlImageSize.png)](https://github.com/L1cardo/qlImageSize)
 
 
 ### [WebP](https://github.com/dchest/webp-quicklook)


### PR DESCRIPTION
Since the origin author doesn't build this plugin for others, I have build one and pushed it to the homebrew-cask.
Now we can download using 'brew cask install qlimagesize'
fixed the issue #92