### PR TITLE
Restore brew cask install qlimagesize

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ The legacy BetterZipQL plugin can be [downloaded here](https://macitbetter.com/d
 
 > Display image size and resolution
 
-~~Run `brew cask install qlimagesize` [(more info)](https://github.com/Homebrew/homebrew-cask/pull/57212)~~ or [download manually](https://github.com/Nyx0uf/qlImageSize#installation)
+Run `brew cask install qlimagesize` or [download manually](https://github.com/Nyx0uf/qlImageSize#installation)
 
 [![](screenshots/qlImageSize.png)](https://github.com/Nyx0uf/qlImageSize)
 


### PR DESCRIPTION
qlImageSize homebrew cask formula is up and running again: https://github.com/Homebrew/homebrew-cask/blob/master/Casks/qlimagesize.rb