### PR TITLE
Remove the trailing slash from ~/Library/QuickLook

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,13 +22,13 @@ To get plugins working in Catalina, you will need to remove the quarantine attri
 Run this to see the attributes:
 
 ```
-xattr -r ~/Library/QuickLook/
+xattr -r ~/Library/QuickLook
 ```
 
 And run this to remove the attributes:
 
 ```
-xattr -d -r com.apple.quarantine ~/Library/QuickLook/
+xattr -d -r com.apple.quarantine ~/Library/QuickLook
 ```
 
 


### PR DESCRIPTION
Run `xattr` against
`~/Library/QuickLook/Q...` instead of
`~/Library/QuickLook//Q...`.